### PR TITLE
keycloak, astrago proxy 연결 추가

### DIFF
--- a/applications/astrago/values.yaml.gotmpl
+++ b/applications/astrago/values.yaml.gotmpl
@@ -13,13 +13,25 @@ core:
     - name: SPRING_DATASOURCE_HIKARI_MAX-LIFETIME
       value: {{ .Values.astrago.mariadb.maxLifetime | quote }}
     - name: SPRING_SECURITY_OAUTH2_RESOURCE-SERVER_JWT_ISSUER-URI
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}/realms/{{ .Values.astrago.keycloak.realm }}
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}
+      {{ end }}
     - name: SPRING_SECURITY_OAUTH2_RESOURCE-SERVER_JWT_JWK-SET-URI
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}/protocol/openid-connect/certs
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}/realms/{{ .Values.astrago.keycloak.realm }}/protocol/openid-connect/certs
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}/protocol/openid-connect/certs
+      {{ end }}
     - name: KEYCLOAK_REALM
       value: {{ .Values.astrago.keycloak.realm }}
     - name: KEYCLOAK_AUTH-SERVER-URL
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}
+      {{ end }}
     - name: KEYCLOAK_RESOURCE
       value: {{ .Values.astrago.keycloak.client }}
     - name: ADMIN_NAME
@@ -45,13 +57,25 @@ batch:
     - name: SPRING_DATASOURCE_HIKARI_MAX-LIFETIME
       value: {{ .Values.astrago.mariadb.maxLifetime | quote }}
     - name: SPRING_SECURITY_OAUTH2_RESOURCE-SERVER_JWT_ISSUER-URI
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}/realms/{{ .Values.astrago.keycloak.realm }}
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}
+      {{ end }}
     - name: SPRING_SECURITY_OAUTH2_RESOURCE-SERVER_JWT_JWK-SET-URI
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}/protocol/openid-connect/certs
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}/realms/{{ .Values.astrago.keycloak.realm }}/protocol/openid-connect/certs
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}/realms/{{ .Values.astrago.keycloak.realm }}/protocol/openid-connect/certs
+      {{ end }}
     - name: KEYCLOAK_REALM
       value: {{ .Values.astrago.keycloak.realm }}
     - name: KEYCLOAK_AUTH-SERVER-URL
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}
+      {{ end }}
     - name: KEYCLOAK_RESOURCE
       value: {{ .Values.astrago.keycloak.client }}
     - name: ADMIN_NAME
@@ -86,7 +110,11 @@ frontend:
     tag: "{{ .Values.astrago.frontend.imageTag }}" 
   env:
     - name: KEYCLOAK_HOST
-      value: http://{{ .Values.externalIP }}:{{ .Values.keycloak.servicePort }}
+      {{ if .Values.astrago.keycloak.externalKeycloakUrl }}
+      value: {{ .Values.astrago.keycloak.externalKeycloakUrl }}
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.keycloak.servicePort }}
+      {{ end }}
     - name: KEYCLOAK_REALME
       value: {{ .Values.astrago.keycloak.realm }}
     - name: KEYCLOAK_CLIENT_ID
@@ -96,7 +124,11 @@ frontend:
     - name: NODE_OPTIONS
       value: "--max-http-header-size=41960"
     - name: NEXTAUTH_URL
-      value: http://{{ .Values.externalIP }}:{{ .Values.astrago.servicePort }}
+      {{ if .Values.astrago.proxyUrl }}
+      value: {{ .Values.astrago.proxyUrl }}
+      {{ else }}
+      value: {{ .Values.connectUrl }}:{{ .Values.astrago.servicePort }}
+      {{ end }}
     - name: NEXTAUTH_SECRET
       value: uuNj1L0Yg2xKcBPVp7yOVlm2nigL3hoHOzbwQXAwx1I=
     - name: NEXT_PUBLIC_API_URL

--- a/environments/dev/values.yaml
+++ b/environments/dev/values.yaml
@@ -1,5 +1,6 @@
 # externalIP: 
-externalIP: 10.61.3.12
+connectUrl: http://10.61.3.12
+
 # Volume Settings
 nfs:
   enabled: true
@@ -11,17 +12,21 @@ local:
   storageClassName: astrago-local-storage
   nodeName:
   basePath:
+
 # Keycloak Settings
 keycloak:
   themeVersion: v1.1.3
   adminUser: admin
   adminPassword: xiirocks
   servicePort: 30001
+
 # Astrago Settings
 astrago:
+  proxyUrl: 
   servicePort: 30080
   userInitPassword: astrago
   keycloak:
+    externalKeycloakUrl: 
     realm: astrago
     client: astrago-client
     clientSecret: astragosecret

--- a/environments/prod/values.yaml
+++ b/environments/prod/values.yaml
@@ -1,5 +1,6 @@
 # externalIP: 
-externalIP:
+connectUrl:
+
 # Volume Settings
 nfs:
   enabled: false
@@ -11,17 +12,21 @@ local:
   storageClassName: astrago-local-storage
   nodeName:
   basePath:
+
 # Keycloak Settings
 keycloak:
   themeVersion: v1.1.3
   adminUser: admin
   adminPassword: xiirocks
   servicePort: 30001
+
 # Astrago Settings
 astrago:
+  proxyUrl:
   servicePort: 30080
   userInitPassword: astrago
   keycloak:
+    externalKeycloakUrl:
     realm: astrago
     client: astrago-client
     clientSecret: astragosecret

--- a/environments/stage/values.yaml
+++ b/environments/stage/values.yaml
@@ -1,5 +1,6 @@
 # externalIP:
-externalIP: 10.61.3.161
+connectUrl: http://10.61.3.161
+
 # Volume Settings
 nfs:
   enabled: true
@@ -11,17 +12,21 @@ local:
   storageClassName: astrago-local-storage
   nodeName:
   basePath:
+
 # Keycloak Settings
 keycloak:
   themeVersion: v1.1.3
   adminUser: admin
   adminPassword: xiirocks
   servicePort: 30001
+
 # Astrago Settings
 astrago:
+  proxyUrl:
   servicePort: 30080
   userInitPassword: astrago
   keycloak:
+    externalKeycloakUrl:
     realm: astrago
     client: astrago-client
     clientSecret: astragosecret


### PR DESCRIPTION
1. 외부 keycloak과 연동할때 사용할 수 있는 externalKeycloakUrl 변수 추가
2. astrago proxy서버와 연동할때 사용할 수 있는 proxyUrl 변수 추가